### PR TITLE
feat: extend get_component_definition to include input/output schema

### DIFF
--- a/src/deepset_mcp/tools/haystack_service.py
+++ b/src/deepset_mcp/tools/haystack_service.py
@@ -60,7 +60,7 @@ async def get_component_definition(client: AsyncClientProtocol, component_type: 
         # Extract component name from the full path
         component_name = component_type.split(".")[-1]
         io_info = await haystack_service.get_component_input_output(component_name)
-        
+
         # Add Input Schema
         parts.append("\nInput Schema:")
         if "input" in io_info:
@@ -107,7 +107,9 @@ async def get_component_definition(client: AsyncClientProtocol, component_type: 
                                     prop_type = prop_info.get("_annotation", prop_info.get("type", "Unknown"))
                                     prop_desc = prop_info.get("description", "No description available.")
                                     default = f" (default: {prop_info['default']})" if "default" in prop_info else ""
-                                    parts.append(f"      {prop_name}: {prop_type}{req_marker}{default}\n        {prop_desc}")
+                                    parts.append(
+                                        f"      {prop_name}: {prop_type}{req_marker}{default}\n        {prop_desc}"
+                                    )
             else:
                 # Simple output schema
                 desc = output_info.get("description", "No description available.")

--- a/test/unit/tools/test_haystack_service.py
+++ b/test/unit/tools/test_haystack_service.py
@@ -79,14 +79,10 @@ async def test_get_component_definition_success() -> None:
     io_response = {
         "input": {
             "properties": {
-                "file_path": {
-                    "_annotation": "str",
-                    "description": "Path to the XLSX file",
-                    "type": "string"
-                }
+                "file_path": {"_annotation": "str", "description": "Path to the XLSX file", "type": "string"}
             },
             "required": ["file_path"],
-            "type": "object"
+            "type": "object",
         },
         "output": {
             "properties": {
@@ -94,7 +90,7 @@ async def test_get_component_definition_success() -> None:
                     "_annotation": "typing.List[haystack.dataclasses.document.Document]",
                     "description": "List of documents",
                     "type": "array",
-                    "items": {"$ref": "#/definitions/Document"}
+                    "items": {"$ref": "#/definitions/Document"},
                 }
             },
             "required": ["documents"],
@@ -103,19 +99,13 @@ async def test_get_component_definition_success() -> None:
                 "Document": {
                     "type": "object",
                     "properties": {
-                        "content": {
-                            "type": "string",
-                            "description": "The content of the document"
-                        },
-                        "meta": {
-                            "type": "object",
-                            "description": "Metadata about the document"
-                        }
+                        "content": {"type": "string", "description": "The content of the document"},
+                        "meta": {"type": "object", "description": "Metadata about the document"},
                     },
-                    "required": ["content"]
+                    "required": ["content"],
                 }
-            }
-        }
+            },
+        },
     }
 
     class FakeHaystackServiceResourceWithIO(FakeHaystackServiceResource):
@@ -134,7 +124,7 @@ async def test_get_component_definition_success() -> None:
     assert "sheet_name" in result
     assert "table_format" in result
     assert "default: csv" in result
-    
+
     # Check input/output schema information
     assert "Input Schema:" in result
     assert "file_path" in result


### PR DESCRIPTION
This PR extends the get_component_definition tool to include component input and output schema information.

Changes made:
- Modified get_component_definition to fetch and include input/output schema
- Added parsing and formatting of input parameters including types, descriptions, required status, and defaults
- Added parsing and formatting of output schema information
- Implemented defensive handling of schema data to avoid errors
- Updated tests to cover the new functionality

The implementation:
1. Extracts the component name from the full path
2. Calls get_component_input_output with the component name
3. Parses and formats the input schema including:
   - Parameter names, types, and descriptions
   - Required field markers
   - Default values where available
4. Parses and formats the output schema including:
   - Output type
   - Description
5. Handles error cases by providing clear messages when:
   - Schema sections are missing
   - Properties are missing
   - Errors occur during schema fetching

Testing:
- Added sample I/O schema data to tests
- Extended test assertions to verify schema formatting
- Verified handling of missing/incomplete schema data
- Confirmed error handling behavior

Closes https://github.com/deepset-ai/deepset-mcp-server/issues/30