### PR TITLE
feat: add create and update methods to IndexResource

### DIFF
--- a/src/deepset_mcp/api/indexes/resource.py
+++ b/src/deepset_mcp/api/indexes/resource.py
@@ -47,57 +47,48 @@ class IndexResource:
 
         return Index.model_validate(response.json)
 
-    async def create(self, name: str, config_yaml: str, description: str | None = None) -> Index:
+    async def create(self, name: str, yaml_config: str, description: str | None = None) -> Index:
         """Create a new index with the given name and configuration.
 
         :param name: Name of the index
-        :param config_yaml: YAML configuration for the index
+        :param yaml_config: YAML configuration for the index
         :param description: Optional description for the index
         :returns: Created index details
         """
         data = {
             "name": name,
-            "config_yaml": config_yaml,
+            "config_yaml": yaml_config,
         }
         if description is not None:
             data["description"] = description
 
-        response = await self._client.request(
-            f"/api/v1/workspaces/{self._workspace}/indexes",
-            method="POST",
-            data=data
-        )
+        response = await self._client.request(f"/api/v1/workspaces/{self._workspace}/indexes", method="POST", data=data)
 
         raise_for_status(response)
 
         return Index.model_validate(response.json)
 
     async def update(
-        self,
-        index_name: str,
-        updated_index_name: str | None = None,
-        config_yaml: str | None = None
+        self, index_name: str, updated_index_name: str | None = None, yaml_config: str | None = None
     ) -> Index:
         """Update name and/or configuration of an existing index.
 
         :param index_name: Name of the index to update
         :param updated_index_name: Optional new name for the index
-        :param config_yaml: Optional new YAML configuration
+        :param yaml_config: Optional new YAML configuration
         :returns: Updated index details
         """
         data = {}
         if updated_index_name is not None:
             data["name"] = updated_index_name
-        if config_yaml is not None:
-            data["config_yaml"] = config_yaml
+        if yaml_config is not None:
+            data["config_yaml"] = yaml_config
 
         if not data:
-            raise ValueError("At least one of updated_index_name or config_yaml must be provided")
+            raise ValueError("At least one of updated_index_name or yaml_config must be provided")
 
         response = await self._client.request(
-            f"/api/v1/workspaces/{self._workspace}/indexes/{index_name}",
-            method="PATCH",
-            data=data
+            f"/api/v1/workspaces/{self._workspace}/indexes/{index_name}", method="PATCH", data=data
         )
 
         raise_for_status(response)

--- a/src/deepset_mcp/api/protocols.py
+++ b/src/deepset_mcp/api/protocols.py
@@ -104,27 +104,24 @@ class IndexResourceProtocol(Protocol):
         """Fetch a single index by its name."""
         ...
 
-    async def create(self, name: str, config_yaml: str, description: str | None = None) -> Index:
+    async def create(self, name: str, yaml_config: str, description: str | None = None) -> Index:
         """Create a new index with the given name and configuration.
 
         :param name: Name of the index
-        :param config_yaml: YAML configuration for the index
+        :param yaml_config: YAML configuration for the index
         :param description: Optional description for the index
         :returns: Created index details
         """
         ...
 
     async def update(
-        self,
-        index_name: str,
-        updated_index_name: str | None = None,
-        config_yaml: str | None = None
+        self, index_name: str, updated_index_name: str | None = None, yaml_config: str | None = None
     ) -> Index:
         """Update name and/or configuration of an existing index.
 
         :param index_name: Name of the index to update
         :param updated_index_name: Optional new name for the index
-        :param config_yaml: Optional new YAML configuration
+        :param yaml_config: Optional new YAML configuration
         :returns: Updated index details
         """
         ...


### PR DESCRIPTION
This PR adds create and update methods to the IndexResource class, along with corresponding updates to the IndexResourceProtocol and unit tests.

Changes made:

1. Updated IndexResourceProtocol to add:
   - create() method for creating new indexes
   - update() method for modifying existing indexes

2. Added new methods to IndexResource:
   - create(): Creates a new index with name, config_yaml and optional description
   - update(): Updates an existing index's name and/or config_yaml

3. Added comprehensive unit tests:
   - test_create_index_successful: Verifies creating a new index
   - test_update_index_successful: Verifies updating an existing index
   - test_update_index_without_changes_fails: Verifies error handling for invalid updates

The implementation follows the patterns from the PipelineResource, particularly for:
- HTTP method usage (POST for create, PATCH for update)
- Parameter handling and validation
- Response processing and model validation
- Error handling

The new methods include proper type hints and reStructuredText docstrings following the project's standards.

Testing:
The implementation has been tested via unit tests that verify:
- Successful creation and update of indexes
- Proper request construction (methods, paths, data)
- Error handling for invalid updates
- Response parsing and model validation

Closes https://github.com/deepset-ai/deepset-mcp-server/issues/44