### PR TITLE
feat: add get_logs tool for pipeline resource

### DIFF
--- a/src/deepset_mcp/main.py
+++ b/src/deepset_mcp/main.py
@@ -298,14 +298,12 @@ async def update_index(
 
 
 @mcp.tool()
-async def get_pipeline_logs(
-    pipeline_name: str, limit: int = 30, level: str | None = None
-) -> str:
+async def get_pipeline_logs(pipeline_name: str, limit: int = 30, level: str | None = None) -> str:
     """Fetches logs for a specific pipeline in the deepset workspace.
-    
+
     Use this to debug pipeline issues, monitor pipeline execution, or understand what happened during pipeline runs.
     The logs provide detailed information about pipeline operations, errors, and warnings.
-    
+
     :param pipeline_name: Name of the pipeline to fetch logs for.
     :param limit: Maximum number of log entries to return (default: 30, max: 100).
     :param level: Filter logs by level. Valid values: 'info', 'warning', 'error'. If not specified, returns all levels.

--- a/src/deepset_mcp/tools/formatting_utils.py
+++ b/src/deepset_mcp/tools/formatting_utils.py
@@ -89,55 +89,55 @@ def validation_result_to_llm_readable_string(validation_result: PipelineValidati
 
 def pipeline_logs_to_llm_readable_string(logs: PipelineLogList, pipeline_name: str, level: str | None = None) -> str:
     """Creates a string representation of pipeline logs that is readable by LLMs.
-    
+
     :param logs: The PipelineLogList containing log entries.
     :param pipeline_name: The name of the pipeline the logs are from.
     :param level: The log level filter that was applied, if any.
-    
+
     :returns: A formatted string representation of the logs.
     """
     if not logs.data:
         filter_info = f" (filtered by level: {level})" if level else ""
         return f"No logs found for pipeline '{pipeline_name}'{filter_info}."
-    
-    log_parts = [
-        f"### Logs for Pipeline '{pipeline_name}'"
-    ]
-    
+
+    log_parts = [f"### Logs for Pipeline '{pipeline_name}'"]
+
     if level:
         log_parts.append(f"**Filter Applied:** Level = {level}")
-    
-    log_parts.extend([
-        f"**Total Logs:** {logs.total}",
-        f"**Showing:** {len(logs.data)} entries",
-        f"**Has More:** {'Yes' if logs.has_more else 'No'}",
-        "\n---\n"
-    ])
-    
+
+    log_parts.extend(
+        [
+            f"**Total Logs:** {logs.total}",
+            f"**Showing:** {len(logs.data)} entries",
+            f"**Has More:** {'Yes' if logs.has_more else 'No'}",
+            "\n---\n",
+        ]
+    )
+
     for i, log in enumerate(logs.data, 1):
         log_entry = [
             f"**Log Entry {i}**",
             f"- **Timestamp:** {log.logged_at.strftime('%B %d, %Y %I:%M:%S %p')}",
             f"- **Level:** {log.level}",
             f"- **Origin:** {log.origin}",
-            f"- **Message:** {log.message}"
+            f"- **Message:** {log.message}",
         ]
-        
+
         if log.exceptions:
             log_entry.append(f"- **Exceptions:** {log.exceptions}")
-        
+
         if log.extra_fields:
             log_entry.append("- **Extra Fields:")
             for key, value in log.extra_fields.items():
                 log_entry.append(f"  - {key}: {value}")
-        
+
         log_parts.append("\n".join(log_entry))
-        
+
         # Add separator between log entries (except for the last one)
         if i < len(logs.data):
             log_parts.append("")
-    
+
     if logs.has_more:
         log_parts.append("\n*Note: There are more log entries available. Adjust the limit parameter to see more.*")
-    
+
     return "\n".join(log_parts)

--- a/src/deepset_mcp/tools/pipeline.py
+++ b/src/deepset_mcp/tools/pipeline.py
@@ -119,23 +119,21 @@ async def get_pipeline_logs(
     level: str | None = None,
 ) -> str:
     """Fetches logs for a specific pipeline.
-    
+
     Retrieves log entries for the specified pipeline, with optional filtering by log level.
     This is useful for debugging pipeline issues or monitoring pipeline execution.
-    
+
     :param client: The async client for API communication.
     :param workspace: The workspace name.
     :param pipeline_name: Name of the pipeline to fetch logs for.
     :param limit: Maximum number of log entries to return (default: 30).
     :param level: Filter logs by level (info, warning, error). If None, returns all levels.
-    
+
     :returns: A formatted string containing the pipeline logs.
     """
     try:
         logs = await client.pipelines(workspace=workspace).get_logs(
-            pipeline_name=pipeline_name,
-            limit=limit,
-            level=level
+            pipeline_name=pipeline_name, limit=limit, level=level
         )
     except ResourceNotFoundError:
         return f"There is no pipeline named '{pipeline_name}' in workspace '{workspace}'."
@@ -143,7 +141,7 @@ async def get_pipeline_logs(
         return f"Failed to fetch logs for pipeline '{pipeline_name}': {e}"
     except UnexpectedAPIError as e:
         return f"Failed to fetch logs for pipeline '{pipeline_name}': {e}"
-    
+
     from deepset_mcp.tools.formatting_utils import pipeline_logs_to_llm_readable_string
-    
+
     return pipeline_logs_to_llm_readable_string(logs, pipeline_name, level)

--- a/test/unit/tools/test_formatting_utils.py
+++ b/test/unit/tools/test_formatting_utils.py
@@ -32,24 +32,24 @@ def test_pipeline_logs_to_llm_readable_string_with_logs() -> None:
         exceptions="ValueError: Invalid document format",
         extra_fields={"component": "document_reader", "file_name": "test.pdf"},
     )
-    
+
     logs = PipelineLogList(data=[log1, log2], has_more=True, total=5)
-    
+
     result = pipeline_logs_to_llm_readable_string(logs, "test-pipeline")
-    
+
     # Check basic structure
     assert "### Logs for Pipeline 'test-pipeline'" in result
     assert "**Total Logs:** 5" in result
     assert "**Showing:** 2 entries" in result
     assert "**Has More:** Yes" in result
-    
+
     # Check log entry 1
     assert "**Log Entry 1**" in result
     assert "**Timestamp:** January 01, 2023 12:00:00 PM" in result
     assert "**Level:** info" in result
     assert "**Origin:** querypipeline" in result
     assert "**Message:** Pipeline started successfully" in result
-    
+
     # Check log entry 2
     assert "**Log Entry 2**" in result
     assert "**Timestamp:** January 01, 2023 12:01:30 PM" in result
@@ -58,7 +58,7 @@ def test_pipeline_logs_to_llm_readable_string_with_logs() -> None:
     assert "**Exceptions:** ValueError: Invalid document format" in result
     assert "component: document_reader" in result
     assert "file_name: test.pdf" in result
-    
+
     # Check pagination note
     assert "*Note: There are more log entries available. Adjust the limit parameter to see more.*" in result
 
@@ -66,18 +66,18 @@ def test_pipeline_logs_to_llm_readable_string_with_logs() -> None:
 def test_pipeline_logs_to_llm_readable_string_empty() -> None:
     """Test formatting empty pipeline logs."""
     logs = PipelineLogList(data=[], has_more=False, total=0)
-    
+
     result = pipeline_logs_to_llm_readable_string(logs, "empty-pipeline")
-    
+
     assert result == "No logs found for pipeline 'empty-pipeline'."
 
 
 def test_pipeline_logs_to_llm_readable_string_empty_with_filter() -> None:
     """Test formatting empty pipeline logs with level filter."""
     logs = PipelineLogList(data=[], has_more=False, total=0)
-    
+
     result = pipeline_logs_to_llm_readable_string(logs, "test-pipeline", level="error")
-    
+
     assert result == "No logs found for pipeline 'test-pipeline' (filtered by level: error)."
 
 
@@ -92,11 +92,11 @@ def test_pipeline_logs_to_llm_readable_string_with_level_filter() -> None:
         exceptions=None,
         extra_fields={},
     )
-    
+
     logs = PipelineLogList(data=[log], has_more=False, total=1)
-    
+
     result = pipeline_logs_to_llm_readable_string(logs, "test-pipeline", level="error")
-    
+
     assert "### Logs for Pipeline 'test-pipeline'" in result
     assert "**Filter Applied:** Level = error" in result
     assert "**Total Logs:** 1" in result
@@ -116,20 +116,20 @@ def test_pipeline_logs_to_llm_readable_string_no_pagination_note() -> None:
         exceptions=None,
         extra_fields={},
     )
-    
+
     logs = PipelineLogList(data=[log], has_more=False, total=1)
-    
+
     result = pipeline_logs_to_llm_readable_string(logs, "test-pipeline")
-    
+
     assert "*Note: There are more log entries available" not in result
 
 
 def test_validation_result_to_llm_readable_string_valid() -> None:
     """Test formatting valid validation result."""
     result = PipelineValidationResult(valid=True, errors=[])
-    
+
     formatted = validation_result_to_llm_readable_string(result)
-    
+
     assert "The provided pipeline configuration is valid." in formatted
     assert "Validation Errors" not in formatted
 
@@ -141,9 +141,9 @@ def test_validation_result_to_llm_readable_string_invalid() -> None:
         ValidationError(code="COMPONENT_ERROR", message="Unknown component type"),
     ]
     result = PipelineValidationResult(valid=False, errors=errors)
-    
+
     formatted = validation_result_to_llm_readable_string(result)
-    
+
     assert "The provided pipeline configuration is invalid." in formatted
     assert "**Validation Errors**" in formatted
     assert "Error 1" in formatted

--- a/test/unit/tools/test_pipeline.py
+++ b/test/unit/tools/test_pipeline.py
@@ -437,12 +437,12 @@ async def test_get_pipeline_logs_success() -> None:
         extra_fields={"component": "reader"},
     )
     logs = PipelineLogList(data=[log1, log2], has_more=False, total=2)
-    
+
     resource = FakePipelineResource(logs_response=logs)
     client = FakeClient(resource)
-    
+
     result = await get_pipeline_logs(client, workspace="ws", pipeline_name="test-pipeline")
-    
+
     assert "Logs for Pipeline 'test-pipeline'" in result
     assert "Pipeline started" in result
     assert "Error occurred" in result
@@ -455,24 +455,24 @@ async def test_get_pipeline_logs_success() -> None:
 @pytest.mark.asyncio
 async def test_get_pipeline_logs_empty() -> None:
     logs = PipelineLogList(data=[], has_more=False, total=0)
-    
+
     resource = FakePipelineResource(logs_response=logs)
     client = FakeClient(resource)
-    
+
     result = await get_pipeline_logs(client, workspace="ws", pipeline_name="test-pipeline")
-    
+
     assert "No logs found for pipeline 'test-pipeline'" in result
 
 
 @pytest.mark.asyncio
 async def test_get_pipeline_logs_with_level_filter() -> None:
     logs = PipelineLogList(data=[], has_more=False, total=0)
-    
+
     resource = FakePipelineResource(logs_response=logs)
     client = FakeClient(resource)
-    
+
     result = await get_pipeline_logs(client, workspace="ws", pipeline_name="test-pipeline", level="error")
-    
+
     assert "No logs found for pipeline 'test-pipeline' (filtered by level: error)" in result
 
 
@@ -480,9 +480,9 @@ async def test_get_pipeline_logs_with_level_filter() -> None:
 async def test_get_pipeline_logs_resource_not_found() -> None:
     resource = FakePipelineResource(logs_exception=ResourceNotFoundError())
     client = FakeClient(resource)
-    
+
     result = await get_pipeline_logs(client, workspace="ws", pipeline_name="missing-pipeline")
-    
+
     assert "There is no pipeline named 'missing-pipeline' in workspace 'ws'" in result
 
 
@@ -490,19 +490,17 @@ async def test_get_pipeline_logs_resource_not_found() -> None:
 async def test_get_pipeline_logs_bad_request() -> None:
     resource = FakePipelineResource(logs_exception=BadRequestError("Invalid level filter"))
     client = FakeClient(resource)
-    
+
     result = await get_pipeline_logs(client, workspace="ws", pipeline_name="test-pipeline")
-    
+
     assert "Failed to fetch logs for pipeline 'test-pipeline': Invalid level filter" in result
 
 
 @pytest.mark.asyncio
 async def test_get_pipeline_logs_unexpected_error() -> None:
-    resource = FakePipelineResource(
-        logs_exception=UnexpectedAPIError(status_code=500, message="Internal server error")
-    )
+    resource = FakePipelineResource(logs_exception=UnexpectedAPIError(status_code=500, message="Internal server error"))
     client = FakeClient(resource)
-    
+
     result = await get_pipeline_logs(client, workspace="ws", pipeline_name="test-pipeline")
-    
+
     assert "Failed to fetch logs for pipeline 'test-pipeline': Internal server error" in result


### PR DESCRIPTION
This PR implements a new tool for the `get_logs` method on the pipeline resource, following the project's established patterns and guidelines.

## Changes Made

### 1. Tool Implementation
- **Added `get_pipeline_logs` function** in `src/deepset_mcp/tools/pipeline.py`
  - Handles fetching logs for a specific pipeline with optional filtering by log level
  - Includes comprehensive error handling for `ResourceNotFoundError`, `BadRequestError`, and `UnexpectedAPIError`
  - Uses the existing `get_logs` method from the pipeline resource

### 2. Formatting Utility
- **Added `pipeline_logs_to_llm_readable_string` function** in `src/deepset_mcp/tools/formatting_utils.py`
  - Formats pipeline logs into a readable string format for LLMs
  - Handles empty log lists with appropriate messaging
  - Shows level filter information when applied
  - Includes pagination information and helpful notes
  - Displays detailed log information including timestamps, levels, messages, exceptions, and extra fields

### 3. MCP Tool Integration
- **Added `get_pipeline_logs` MCP tool** in `src/deepset_mcp/main.py`
  - Exposes the functionality through the MCP server
  - Includes comprehensive docstring with usage instructions
  - Supports parameters: `pipeline_name`, `limit` (default: 30), and `level` (optional filter)

### 4. Testing
- **Extended unit tests** in `test/unit/tools/test_pipeline.py`
  - Added comprehensive tests for `get_pipeline_logs` function covering:
    - Success scenarios with logs
    - Empty log responses
    - Level filtering
    - Error handling (ResourceNotFoundError, BadRequestError, UnexpectedAPIError)
    - Updated `FakePipelineResource` to support logs testing

- **Added formatting utility tests** in `test/unit/tools/test_formatting_utils.py`
  - Tests for `pipeline_logs_to_llm_readable_string` covering:
    - Logs with data and various log levels
    - Empty log lists
    - Level filtering
    - Pagination scenarios
    - Edge cases and special formatting

- **Extended API resource tests** in `test/unit/api/pipeline/test_pipeline_resource.py`
  - Added comprehensive tests for the `get_logs` method covering:
    - Default parameters
    - Custom limits and level filters
    - Empty responses and null handling
    - Error scenarios
    - Edge cases like special characters in pipeline names
    - Preservation of extra fields

## Implementation Details

The implementation follows the project's established patterns:

1. **Tool Structure**: The tool makes API calls through the client and formats responses using helper functions
2. **Error Handling**: Comprehensive exception handling with user-friendly error messages
3. **Code Style**: Follows reStructuredText docstring style and maintains consistency with existing code
4. **Testing**: Complete unit test coverage following the project's testing patterns
5. **Dependencies**: Uses existing infrastructure without introducing new dependencies

## Usage

The new tool can be used by LLMs to fetch and analyze pipeline logs for debugging and monitoring purposes:

```python
# Get recent logs for a pipeline
await get_pipeline_logs("my-pipeline")

# Get error logs only
await get_pipeline_logs("my-pipeline", level="error")

# Get more logs
await get_pipeline_logs("my-pipeline", limit=50)
```

## Testing Considerations

The implementation includes comprehensive unit tests covering all code paths. The tests use the existing fake client pattern and mock appropriate responses for various scenarios. No integration tests were added as per project guidelines for tool testing.

Closes https://github.com/deepset-ai/deepset-mcp-server/issues/62