### PR TITLE
fix: create_pipeline tool kwarg mismatch (BUI-670)

### DIFF
--- a/src/deepset_mcp/api/pipeline/protocols.py
+++ b/src/deepset_mcp/api/pipeline/protocols.py
@@ -32,7 +32,7 @@ class PipelineResourceProtocol(Protocol):
         """List pipelines in the configured workspace with optional pagination."""
         ...
 
-    async def create(self, name: str, yaml_config: str) -> NoContentResponse:
+    async def create(self, pipeline_name: str, yaml_config: str) -> NoContentResponse:
         """Create a new pipeline with a name and YAML config."""
         ...
 

--- a/src/deepset_mcp/tools/pipeline.py
+++ b/src/deepset_mcp/tools/pipeline.py
@@ -128,7 +128,7 @@ async def create_pipeline(
             error_messages = [f"{error.code}: {error.message}" for error in validation_response.errors]
             return "Pipeline validation failed:\n" + "\n".join(error_messages)
 
-        await client.pipelines(workspace=workspace).create(name=pipeline_name, yaml_config=yaml_configuration)
+        await client.pipelines(workspace=workspace).create(pipeline_name=pipeline_name, yaml_config=yaml_configuration)
 
         # Get the full pipeline after creation
         pipeline = await client.pipelines(workspace=workspace).get(pipeline_name)

--- a/test/unit/tools/test_doc_search.py
+++ b/test/unit/tools/test_doc_search.py
@@ -77,7 +77,7 @@ class FakeDocsPipelineResource(PipelineResourceProtocol):
     ) -> PaginatedResponse[DeepsetPipeline]:
         raise NotImplementedError
 
-    async def create(self, name: str, yaml_config: str) -> NoContentResponse:
+    async def create(self, pipeline_name: str, yaml_config: str) -> NoContentResponse:
         raise NotImplementedError
 
     async def list_versions(

--- a/test/unit/tools/test_pipeline.py
+++ b/test/unit/tools/test_pipeline.py
@@ -139,7 +139,7 @@ class FakePipelineResource:
             return self._validate_response
         raise NotImplementedError
 
-    async def create(self, name: str, yaml_config: str) -> NoContentResponse:
+    async def create(self, pipeline_name: str, yaml_config: str) -> NoContentResponse:
         if self._create_exception:
             raise self._create_exception
         if self._create_response is not None:


### PR DESCRIPTION
## Summary
- Fixes [BUI-670](https://linear.app/deepset/issue/BUI-670/create-pipeline-tool-in-deepset-mcp-broken): `create_pipeline` failed with `PipelineResource.create() got an unexpected keyword argument 'name'`.
- Root cause: the protocol and tool caller used kwarg `name`, but `PipelineResource.create` is defined with `pipeline_name`. Mocks followed the protocol, so unit tests passed while the real call failed.
- Aligned protocol, caller, and test mocks on `pipeline_name` to match the implementation and the rest of the pipeline resource API.

## Test plan
- [x] `uv run pytest test/unit/tools/test_pipeline.py test/unit/api/pipeline/test_pipeline_resource.py test/unit/tools/test_doc_search.py` passes
- [x] `uv run mypy` clean on changed files
- [ ] Manual verification: invoke `create_pipeline` via deepset-mcp against a real workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)