### PR TITLE
fix: OBJECT_STORE_TTL env var overrides explicit --object-store-ttl flag

### DIFF
--- a/src/deepset_mcp/main.py
+++ b/src/deepset_mcp/main.py
@@ -106,13 +106,13 @@ def main(
         ),
     ] = None,
     object_store_ttl: Annotated[
-        int,
+        int | None,
         typer.Option(
             "--object-store-ttl",
             help="TTL in seconds for stored objects. Default: 600 (10 minutes). "
             "Can also be set via OBJECT_STORE_TTL environment variable.",
         ),
-    ] = 600,
+    ] = None,
     host: Annotated[
         str,
         typer.Option(
@@ -164,7 +164,7 @@ def main(
     # ObjectStore configuration
     backend = str(object_store_backend or os.getenv("OBJECT_STORE_BACKEND", "memory"))
     redis_url = object_store_redis_url or os.getenv("OBJECT_STORE_REDIS_URL")
-    ttl = int(os.getenv("OBJECT_STORE_TTL", str(object_store_ttl)))
+    ttl = object_store_ttl or int(os.getenv("OBJECT_STORE_TTL", "600"))
 
     if tools:
         tool_names = set(tools)


### PR DESCRIPTION
Every other option here follows CLI arg wins, env var as fallback, but `ttl` always read `os.getenv()` first, so setting `OBJECT_STORE_TTL` in the environment silently overrode an explicit `--object-store-ttl` flag. Changed the default to `None` so it follows the same fallback chain as the other options in this function. No existing test covered this, so nothing to update there — happy to add one if you'd like.